### PR TITLE
Add default project selection

### DIFF
--- a/src/components/ProyectoCard.jsx
+++ b/src/components/ProyectoCard.jsx
@@ -3,7 +3,7 @@ import AppContext from '../context/AppContext'
 import TareaCard from './TareaCard'
 
 const ProyectoCard = ({ project }) => {
-  const { addTask } = useContext(AppContext)
+  const { addTask, setDefaultProject } = useContext(AppContext)
   const [showTasks, setShowTasks] = useState(false)
   const [taskTitle, setTaskTitle] = useState('')
 
@@ -14,11 +14,14 @@ const ProyectoCard = ({ project }) => {
   }
 
   return (
-    <div className="border p-2 mb-2">
+    <div className={`border p-2 mb-2 ${project.isDefault ? 'bg-yellow-100' : ''}`}>
       <div className="flex justify-between items-center">
         <h2 className="font-bold" onClick={() => setShowTasks(!showTasks)}>
           {project.name}
         </h2>
+        <button onClick={() => setDefaultProject(project.id)} className="text-xl">
+          {project.isDefault ? '★' : '☆'}
+        </button>
       </div>
       {showTasks && (
         <div className="ml-4 mt-2">

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -17,25 +17,56 @@ export const AppProvider = ({ children }) => {
   }, [projects])
 
   const addProject = (name) => {
-    setProjects([...projects, { id: Date.now(), name, tasks: [] }])
+    setProjects([
+      ...projects,
+      { id: Date.now(), name, tasks: [], isDefault: false }
+    ])
+  }
+
+  const setDefaultProject = (projectId) => {
+    setProjects(projects.map(p => ({
+      ...p,
+      isDefault: p.id === projectId
+    })))
   }
 
   const addTask = (projectId, title) => {
-    setProjects(projects.map(p => p.id === projectId ? { ...p, tasks: [...p.tasks, { id: Date.now(), title, activities: [], status: 'backlog' }] } : p))
+    setProjects(
+      projects.map(p =>
+        p.id === projectId
+          ? {
+              ...p,
+              tasks: [
+                ...p.tasks,
+                { id: Date.now(), title, activities: [], status: 'backlog' }
+              ]
+            }
+          : p
+      )
+    )
   }
 
   const addActivity = (projectId, taskId, activity) => {
-    setProjects(projects.map(p => {
-      if (p.id !== projectId) return p
-      return {
-        ...p,
-        tasks: p.tasks.map(t => t.id === taskId ? { ...t, activities: [...t.activities, { ...activity, id: Date.now() }] } : t)
-      }
-    }))
+    setProjects(
+      projects.map(p => {
+        if (p.id !== projectId) return p
+        return {
+          ...p,
+          tasks: p.tasks.map(t =>
+            t.id === taskId
+              ? {
+                  ...t,
+                  activities: [...t.activities, { ...activity, id: Date.now() }]
+                }
+              : t
+          )
+        }
+      })
+    )
   }
 
   return (
-    <AppContext.Provider value={{ projects, addProject, addTask, addActivity }}>
+    <AppContext.Provider value={{ projects, addProject, addTask, addActivity, setDefaultProject }}>
       {children}
     </AppContext.Provider>
   )


### PR DESCRIPTION
## Summary
- mark projects with an `isDefault` flag
- add a `setDefaultProject` context method
- show a star button on each project card to mark as default
- highlight the default project

## Testing
- `npm run dev` *(fails: vite not found until packages installed; after installing, server starts)*

------
https://chatgpt.com/codex/tasks/task_e_684453020af08327b3dc4661599ba5a4