### PR TITLE
Add widget view for active tasks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,18 @@
 import './App.css'
+import { useState } from 'react'
 import { AppProvider } from './context/AppContext'
 import ProyectosView from './views/ProyectosView'
+import WidgetView from './views/WidgetView'
 
 function App() {
+  const [view, setView] = useState('projects')
   return (
     <AppProvider>
-      <ProyectosView />
+      {view === 'widget' ? (
+        <WidgetView onGoMain={() => setView('projects')} />
+      ) : (
+        <ProyectosView />
+      )}
     </AppProvider>
   )
 }

--- a/src/views/WidgetView.jsx
+++ b/src/views/WidgetView.jsx
@@ -1,0 +1,75 @@
+import React, { useContext, useState } from 'react'
+import AppContext from '../context/AppContext'
+
+const WidgetView = ({ onGoMain }) => {
+  const { projects, addTask } = useContext(AppContext)
+  const defaultProject = projects.find(p => p.isDefault)
+  const activeTasks = projects.flatMap(p =>
+    p.tasks
+      .filter(t => t.status === 'en desarrollo')
+      .map(t => ({ ...t, projectName: p.name }))
+  )
+
+  const [title, setTitle] = useState('')
+  const [hours, setHours] = useState('0')
+
+  const handleAdd = () => {
+    if (!title || !defaultProject) return
+    addTask(defaultProject.id, title, hours)
+    setTitle('')
+    setHours('0')
+  }
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-lg font-bold mb-4">Tareas en curso</h1>
+      {activeTasks.length ? (
+        <ul className="space-y-2">
+          {activeTasks.map(t => (
+            <li key={t.id} className="bg-white border rounded p-2">
+              <div className="font-semibold">{t.title}</div>
+              <div className="text-sm text-gray-600">{t.projectName}</div>
+            </li>
+          ))}
+        </ul>
+      ) : defaultProject ? (
+        <div className="space-y-2">
+          <p className="text-sm text-gray-700">No hay tareas en curso</p>
+          <input
+            className="border rounded px-2 py-1 w-full"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="Nueva tarea"
+          />
+          <input
+            className="border rounded px-2 py-1 w-full"
+            type="number"
+            value={hours}
+            onChange={e => setHours(e.target.value)}
+            placeholder="Horas"
+          />
+          <button
+            className="bg-blue-600 text-white px-3 py-1 rounded w-full"
+            onClick={handleAdd}
+          >
+            Agregar tarea
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-sm text-gray-700">No hay proyecto predeterminado</p>
+          {onGoMain && (
+            <button
+              className="bg-blue-600 text-white px-3 py-1 rounded w-full"
+              onClick={onGoMain}
+            >
+              Ir a proyectos
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default WidgetView


### PR DESCRIPTION
## Summary
- introduce `WidgetView` to show tasks with status `en desarrollo`
- allow adding a task to the default project when no active tasks exist
- button to go back to projects if no default project is defined
- wire new view through App state

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bed7b1b88327b95d1fa283c3a6e8